### PR TITLE
add option for alphanumerical prediction symbol WIP

### DIFF
--- a/src/GaussianNB.js
+++ b/src/GaussianNB.js
@@ -11,9 +11,11 @@ export class GaussianNB {
    * @param {object} model
    */
   constructor(reload, model) {
+    this.predictionsSymbolMap = {};
     if (reload) {
       this.means = model.means;
       this.calculateProbabilities = model.calculateProbabilities;
+      this.predictionsSymbolMap = model.predictionsSymbolMap;
     }
   }
 
@@ -37,10 +39,13 @@ export class GaussianNB {
       );
     }
 
-    var separatedClasses = separateClasses(trainingSet, trainingLabels);
+    var sc = separateClasses(trainingSet, trainingLabels);
+    var separatedClasses = sc.separatedClasses;
+    var classesMap = sc.actualClassesMap;
     var calculateProbabilities = new Array(separatedClasses.length);
     this.means = new Array(separatedClasses.length);
     for (var i = 0; i < separatedClasses.length; ++i) {
+      this.predictionsSymbolMap[i] = classesMap[i];
       var means = Stat.matrix.mean(separatedClasses[i]);
       var std = Stat.matrix.standardDeviation(separatedClasses[i], means);
 
@@ -87,7 +92,7 @@ export class GaussianNB {
       );
     }
 
-    return predictions;
+    return predictions.map((i) => this.predictionsSymbolMap[i]);
   }
 
   /**
@@ -98,7 +103,8 @@ export class GaussianNB {
     return {
       modelName: 'NaiveBayes',
       means: this.means,
-      calculateProbabilities: this.calculateProbabilities
+      calculateProbabilities: this.calculateProbabilities,
+      predictionsSymbolMap: this.predictionsSymbolMap
     };
   }
 

--- a/src/__tests__/GaussianNB.js
+++ b/src/__tests__/GaussianNB.js
@@ -15,13 +15,31 @@ describe('Naive bayes', () => {
     expect(results).toEqual(predictions);
   });
 
-  test('separate classes', () => {
+  test('Separate classes', () => {
     var matrixCases = new Matrix(cases);
-    var separatedResult = separateClasses(matrixCases, predictions);
+    var sc = separateClasses(matrixCases, predictions);
 
+    var separatedResult = sc.separatedClasses;
+    var symbols = sc.actualClassesMap;
     expect(separatedResult).toHaveLength(2);
     expect(separatedResult[0].rows).toEqual(3);
     expect(separatedResult[1].rows).toEqual(2);
+    expect(symbols).toEqual([0, 1]);
+  });
+
+  test('Separate classes where predictions are non related alphanumerical symbols', () => {
+    const cases = [[0, 0], [0, 1], [1, 0], [1, 1], [2, 2]];
+    const predictions = [-1, -1, -1, 'a', 'a'];
+
+    var matrixCases = new Matrix(cases);
+    var sc = separateClasses(matrixCases, predictions);
+    var separatedResult = sc.separatedClasses;
+    var symbols = sc.actualClassesMap;
+
+    expect(Object.keys(separatedResult)).toHaveLength(2);
+    expect(separatedResult[0].rows).toEqual(3);
+    expect(separatedResult[1].rows).toEqual(2);
+    expect(symbols).toEqual([-1, 'a']);
   });
 
   test('Small test', () => {
@@ -33,6 +51,22 @@ describe('Naive bayes', () => {
       [0, 137, 40, 35, 168, 43.1, 2.288, 33]
     ];
     var predictions = [1, 0, 1, 0, 1];
+    var nb = new GaussianNB();
+    nb.train(cases, predictions);
+    var result = nb.predict(cases);
+
+    expect(result).toEqual(predictions);
+  });
+
+  test('Small test where predictions are non related alphanumerical symbols', () => {
+    var cases = [
+      [6, 148, 72, 35, 0, 33.6, 0.627, 5],
+      [1.5, 85, 66.5, 29, 0, 26.6, 0.351, 31],
+      [8, 183, 64, 0, 0, 23.3, 0.672, 32],
+      [0.5, 89, 65.5, 23, 94, 28.1, 0.167, 21],
+      [0, 137, 40, 35, 168, 43.1, 2.288, 33]
+    ];
+    var predictions = [-1, 'a', -1, 'a', -1];
     var nb = new GaussianNB();
     nb.train(cases, predictions);
     var result = nb.predict(cases);

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,16 +5,23 @@ import Matrix from 'ml-matrix';
  * Function that retuns an array of matrices of the cases that belong to each class.
  * @param {Matrix} X - dataset
  * @param {Array} y - predictions
- * @return {Array}
+ * @return {Object} An object containing the separated classes array and another array with the prediction symbols
  */
 export function separateClasses(X, y) {
   var features = X.columns;
 
   var classes = 0;
   var totalPerClasses = new Array(10000); // max upperbound of classes
+  var actualClassesMap = [];
+  var usedClasses = {};
+  var reverseClasses = {};
+
   for (var i = 0; i < y.length; i++) {
-    if (totalPerClasses[y[i]] === undefined) {
+    if (!usedClasses[y[i]]) {
+      usedClasses[y[i]] = true;
       totalPerClasses[y[i]] = 0;
+      reverseClasses[y[i]] = actualClassesMap.length;
+      actualClassesMap.push(y[i]);
       classes++;
     }
     totalPerClasses[y[i]]++;
@@ -22,12 +29,17 @@ export function separateClasses(X, y) {
   var separatedClasses = new Array(classes);
   var currentIndex = new Array(classes);
   for (i = 0; i < classes; ++i) {
-    separatedClasses[i] = new Matrix(totalPerClasses[i], features);
+    separatedClasses[i] = new Matrix(totalPerClasses[actualClassesMap[i]], features);
     currentIndex[i] = 0;
   }
   for (i = 0; i < X.rows; ++i) {
-    separatedClasses[y[i]].setRow(currentIndex[y[i]], X.getRow(i));
-    currentIndex[y[i]]++;
+    var index = reverseClasses[y[i]];
+    separatedClasses[index].setRow(currentIndex[index], X.getRow(i));
+    currentIndex[index]++;
   }
-  return separatedClasses;
+
+  return {
+    separatedClasses,
+    actualClassesMap
+  };
 }


### PR DESCRIPTION
My fix for this issue that was least invasive. Check the additional tests in `/GaussianNB`, it now supports a lot of chars, numbers, etc. as prediction symbols, not only consecutive positive integers. I hat to change what `separateClasses` returns though and because of this the tests for `/MultinomialNB` and the rest fail, I haven't updated that part of the code. 

**Someone maintaining this repo please let me know if they are OK with this direction so far so that I can update the rest of the code and make the rest of the tests pass**